### PR TITLE
feat: add data practice privacy contributions

### DIFF
--- a/playbook/docs/getting-started/responsibleai.md
+++ b/playbook/docs/getting-started/responsibleai.md
@@ -43,6 +43,8 @@ As the old adage goes, "garbage in, garbage out". If unsafe or biased data is us
 
 In the Generative AI space, LLMs are typically pre-trained on massive amounts of text or image data from the Internet, which contain harmful, toxic and biased texts. Since LLMs autoregressively generate the next most probable token, the output depends on the joint distribution of tokens learned during training. If unsafe token sequences are learned, they will naturally be reproduced by the model, as ChatGPT did in its early days. For image generation models, there have been several studies finding that generated outputs of engineers, scientists, or lawyers disproportionately portray men over women, reflecting the unequal gender representation of those occupations in the training data.
 
+Furthermore, this massive scale of data collection introduces [severe privacy risks](https://arxiv.org/pdf/2506.17185). Given that the training of foundational models often rely on indiscriminate web scraping, the resulting training datasets inadvertently contain Personally Identifiable Information (PII) such as names, phone numbers, addresses, and private emails without the data subjects' explicit consent. If this data is not rigorously filtered or anonymized prior to training, models can memorize and subsequently regurgitate this sensitive information to end users, directly enabling [severe harms such as identity theft and fraud](https://www.ijcai.org/proceedings/2025/1156.pdf).
+
 ### Model
 
 In discriminative AI settings, the choice of modelling parameters can greatly impact their fairness. One key consideration is whether to include sensitive variables (i.e. variables about protected attributes like race or gender) in the model. On one hand, including these variables may result in bias against specific groups, such as ageist and sexist bias in online recruitment software. However, algorithmic bias has also been shown to persist even in models that deliberately exclude sensitive variables from the model, such as with recidivism prediction (i.e. COMPAS) or with delivery services (i.e. Amazon Prime).
@@ -51,9 +53,13 @@ In the generative AI space, significant research has been dedicated to aligning 
 
 Another significant research direction entails analysing harmfulness and toxicity in LLM neurons and layers. Having found the weights or activations that are most responsible for toxicity, it is then possible to edit the models to reduce the incidence of harmful outputs. This is typically known as a white box approach to tackling model harmfulness. 
 
+Alongside fairness and toxicity, the tendency of models to memorise training data often leads to the direct regurgitation of PII, Protected Health Information (PHI), or proprietary code from the training corpus. Furthermore, even when raw data is not explicitly exposed, attackers can exploit model weights and predictive probabilities. [Membership inference attacks](https://ieeexplore.ieee.org/document/9793586) can determine if specific records were used in training, while [model inversion attacks](https://rist.tech.cornell.edu/papers/mi-ccs.pdf) can reconstruct sensitive input features. 
+
 ### Application
 
-Finally, when an AI model is embedded into a software application, the way users interact with the application may also result in significant risks. For example, users may intentionally probe the application to exfiltrate sensitive data or elicit harmful outputs at scale. To address this risk, input and output guardrails have emerged as viable defences. Guardrails are typically known as black-box defences as they do not require access to the models and can be easily deployed in the application layer. 
+Finally, when an AI model is embedded into a software application, the way users interact with the application may also result in significant risks. For example, users may intentionally probe the application to exfiltrate sensitive data or elicit harmful outputs at scale. Even well-intentioned users pose a risk by inadvertently including Personally Identifiable Information (PII) in their prompts, which can lead to data leakage if the application logs or trains on user interactions. To address this risk, input and output guardrails have emerged as viable defences. Guardrails are typically known as black-box defences as they do not require access to the models and can be easily deployed in the application layer.
+
+For a deeper look at how privacy vulnerabilities emerge across the layers, see the chapter [Identifying Privacy Risks](https://go.gov.sg/identifying-privacy-risks-for-rai) in GovTech Data Practice's AI Privacy publication.
 
 ## Our Approach
 
@@ -80,7 +86,11 @@ Refer to the section on [testing](../testing.md) for details.
 
 ### Mitigation
 
-After testing is completed, mitigation measures can then be adopted, where applicable and appropriate. A common mitigation measure is finetuning or alignment, in which AI models are trained to output human-preferred responses, or aligned to human values, requiring access to model weights. On the other hand, mitigations at the application level in the form of guardrails are more general and can be widely applied to different contexts. 
+After testing is completed, mitigation measures can then be adopted, where applicable and appropriate. A common mitigation measure is finetuning or alignment, in which AI models are trained to output human-preferred responses, or aligned to human values, requiring access to model weights. 
+
+To address the privacy risks associated with data collection and model memorization, Privacy-Enhancing Technologies serve as a crucial line of defense. As a data-level mitigation, Synthetic Data Generation allows organizations to train downstream models without exposing actual PII by creating artificial datasets that mirror the statistical properties of real-world data. One can also apply Differential Privacy during model training to introduce mathematically calibrated noise, ensuring the model learns broad statistical patterns without memorizing individual, sensitive records. Frameworks like Federated Learning enable models to train on decentralized devices, keeping raw data localized and eliminating the risk of centralized data breaches. For more information, see the chapter [Mitigating Privacy Risks for RAI](https://go.gov.sg/mitigating-privacy-risks-for-rai) within GovTech Data Practice's AI Privacy publication. 
+
+On the other hand, mitigations at the application level in the form of guardrails are more general and can be widely applied to different contexts.
 
 Refer to the section on [guardrails](../guardrails.md) for details. 
 

--- a/playbook/docs/guardrails/diff_guardrails.md
+++ b/playbook/docs/guardrails/diff_guardrails.md
@@ -27,11 +27,11 @@ Generic moderation models may not be sufficiently localized for specific context
 
 ## 2. Personal Identifiable Information (PII)
 
-We do not want to pass PII to LLMs, especially when the LLM is accessed via an external managed service. 
+We do not want to pass direct identifiers (like names and emails) and indirect identifiers (like postal codes, date of birth, gender or job titles) to LLMs, especially when the LLM is accessed via an external managed service. While indirect identifiers do not point to a specific person on their own, the advanced capabilities of LLMs pose an [increasing risk](https://arxiv.org/pdf/2310.07298), as they can easily piece such fragments together with other data to infer sensitive personal attributes.
 
 To detect PII, we can use:
 
-- [Cloak](https://cloak.gov.sg) - GovTech's dedicated internal service for comprehensive and localised PII detection (e.g., names, addresses). Direct integration with Sentinel API is coming soon.
+- [Cloak](https://cloak.gov.sg) - GovTech's dedicated internal service for comprehensive and localised PII detection (e.g., names, addresses). Beyond the standard PII types, Cloak also offers LLM-enabled custom entity detection to protect custom, domain-specific or localised entities unique to your use case. Direct integration with Sentinel API is coming soon.
 - [Presidio](https://github.com/microsoft/presidio) - Open source tool that identifies various PII entities like names, phone numbers, addresses
 - Custom regex patterns for basic PII detection
 

--- a/playbook/docs/testing.md
+++ b/playbook/docs/testing.md
@@ -57,6 +57,12 @@ Agentic systems are often more prone to unsafe behaviors than their base models,
 
 See [agentic testing](testing/agentic_testing/agentic_testing.md) for details. 
 
+### Privacy Testing 🔒
+
+Privacy testing evaluates a system's ability to protect sensitive data throughout the AI lifecycle from the data used to train the model to the information handled during real-time inference. This ensures that sensitive data remains confidential and that the model does not inadvertently disclose protected information.
+
+See [privacy testing](testing/privacy_testing/privacy_testing.md) for details.
+
 ## Responsible AI Benchmark
 
 We have developed the Responsible AI Benchmark, a collection of **application-level safety, robustness and fairness tests** designed around real-world use cases. The benchmark serves as a rough guide for developers in filtering down a subset of appropriate models for their use case. However, it is still necessary for application developers to conduct their own testing before deployment. 

--- a/playbook/docs/testing/privacy_testing/privacy_testing.md
+++ b/playbook/docs/testing/privacy_testing/privacy_testing.md
@@ -1,0 +1,18 @@
+# Privacy Testing
+
+In the era of generative AI and foundation models, privacy can no longer be treated as a static compliance checkbox; it is a dynamic property that must be evaluated across the entire lifecycle of an AI system. Protecting an AI ecosystem requires a comprehensive approach that measures and tests privacy risks at three distinct layers: the data, the model, and the application.
+
+## The Data Layer
+
+The Data Layer serves as the foundation, where privacy vulnerabilities at data ingestion become fundamentally baked into the model's weights. The primary goal here is to measure the risk of individual-level linkage, which refers to the ability to connect data back to a specific person. This involves quantifying Personally Identifiable Information (PII) density within the datasets using descriptive metrics like entity frequency, while utilizing precision, recall, and F1 scores to evaluate the effectiveness of the automated PII scrubbers. It also requires applying privacy models like [_k_-anonymity](https://www.worldscientific.com/doi/abs/10.1142/S0218488502001648), [_l_-diversity](https://dl.acm.org/doi/10.1145/1217299.1217302), and [_t_-closeness](https://www.cs.purdue.edu/homes/ninghui/papers/t_closeness_icde07.pdf) to measure vulnerability to linkage attacks and re-identification via auxiliary public records. In unstructured text data, simulations of attribute inference attacks can be used to determine how easily adversaries can infer hidden attributes such as medical status or political affiliations from semantic context, even when explicit identifiers are scrubbed.
+
+## The Model Layer
+
+The Model Layer introduces the danger of machine learning models, especially Large Language Models, memorizing their training data or learning feature correlations that malicious actors can exploit to reverse-engineer sensitive training data. Testing at this level relies on simulated attacks to establish empirical privacy metrics: automated [data extraction attacks](https://arxiv.org/abs/2311.17035) measure how often the model regurgitates sensitive training data verbatim, [membership inference attacks](https://ieeexplore.ieee.org/document/9793586) quantify the probability of deducing an individual's presence in the training set, and [model inversion attacks](https://rist.tech.cornell.edu/papers/mi-ccs.pdf) evaluate whether demographic profiles or exact identities can be reconstructed from the model's outputs.
+
+## The Application Layer
+
+The Application Layer introduces new attack vectors when the AI interface interacts with users, databases, or third-party APIs. Adversarial red teaming and prompt injections can be used to bypass safety guardrails and leak proprietary instructions and private context. Mitigating these risks requires strict access control auditing to ensure the system respects Role-Based Access Controls (RBAC), guaranteeing that users only generate insights from data they are explicitly authorized to query.
+
+!!! note "Learn More"
+    By decoupling the AI lifecycle into these three layers, we can deploy targeted testing methodologies that transition privacy from a reactive obligation to a proactive engineering standard. For more details, see the [Measuring Privacy Risks](https://go.gov.sg/measuring-privacy-risks-for-rai) chapter in GovTech Data Practice's AI Privacy publication.

--- a/playbook/mkdocs.yml
+++ b/playbook/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
           - Introduction: testing/robustness_testing/robustness_testing.md
       - Agentic AI:
           - Introduction: testing/agentic_testing/agentic_testing.md
+      - Privacy:
+          - Introduction: testing/privacy_testing/privacy_testing.md
       - Litmus: testing/litmus.md
   - Guardrails:
       - Introduction: guardrails.md


### PR DESCRIPTION
## Summary

- Add new privacy testing section covering data, model, and application layer privacy risks with references to GovTech Data Practice's AI Privacy publication
- Expand the Responsible AI page with detailed privacy risk coverage across the AI lifecycle (data collection, model memorization, application-layer leakage)
- Enhance PII guardrails documentation with indirect identifiers, LLM re-identification risks, and Cloak's custom entity detection capabilities
- Embed references to Data Practice's AI Privacy publication for readers interested in more details

## Changes

- **New:** `playbook/docs/testing/privacy_testing/privacy_testing.md` — privacy testing guide (data/model/application layers)
- **Updated:** `playbook/docs/getting-started/responsibleai.md` — added privacy risk sections 
- **Updated:** `playbook/docs/guardrails/diff_guardrails.md` — expanded PII detection guidance (indirect identifiers, Cloak custom entities)
- **Updated:** `playbook/docs/testing.md` — added privacy testing entry to testing overview
- **Updated:** `playbook/mkdocs.yml`— added privacy testing in navigation